### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-#Android Kernel Kitchen
+# Android Kernel Kitchen
 tools to tinker with kernels and ramdisks   
 [![Contact me on Codementor](https://cdn.codementor.io/badges/contact_me_github.svg)](https://www.codementor.io/championswimmer?utm_source=github&utm_medium=button&utm_term=championswimmer&utm_campaign=github)
 
 ## Install Pre-requisite Packages
 
-####Java archiver 'jar' tool (only required if you work with ftf files)
+#### Java archiver 'jar' tool (only required if you work with ftf files)
 If you have java, jre, open-jdk or sun-java-jdk installed then jar should be already present in your system, other wise install it by running   
 
 	sudo apt-get install fastjar   
 
 For cygwin users, you have to install the sun java jre BEFORE installing cygwin
 
-####ImageMagick (only for bootsplash image editing)
+#### ImageMagick (only for bootsplash image editing)
 This is required for linux users. For cygwin, precompiled binary is already present.   
 
 	sudo apt-get install imagemagick   
 
-####GNU C Compiler ( not required for Linux x86_64)
+#### GNU C Compiler ( not required for Linux x86_64)
 Some funtions need precompiled binaries for your architecture to work. The sources are already present inside the kitchen and the binaries will be compiled during execution. (as I'm using Linux 64bit, binaries for this architecture are already present)   
 
 
@@ -25,7 +25,7 @@ Some funtions need precompiled binaries for your architecture to work. The sourc
 **********
 __________
 
-##How to use
+## How to use
 
 go to terminal, cd to the top directory of kitchen and run   
 
@@ -37,7 +37,7 @@ or if you are on ubuntu you can just double-click menu and click "Run in Termina
 ___________________
 ___________________
 ___________________
-###For advanced manual usage, without using menu, read instructions below
+### For advanced manual usage, without using menu, read instructions below
 ___________________
 ___________________
 ___________________
@@ -52,7 +52,7 @@ ___________________
 
 
 
-####Working with boot.img files 
+#### Working with boot.img files 
 
 ##### 1. unpacking kernel contents from boot.img
 This unpacks zImage and initrd.img (ramdisk) from boot.img   
@@ -86,7 +86,7 @@ or for more advanced funtionality call the zimage and ramdisk through arguement
 
 **********
 __________
-####Working with FTF and SIN files (for Xperia with Flashtool)   
+#### Working with FTF and SIN files (for Xperia with Flashtool)   
 
 ##### 1. Unpacking kernel contents from ftf 
 (required for Xperia 2010, 2011, 2012 series of smartphones only)
@@ -140,9 +140,9 @@ and they should be named "image" and "ramdisk"
 
 ***************
 _______________
-####Working with Ramdisks
+#### Working with Ramdisks
 
-#####1. Extracting ramdisks
+##### 1. Extracting ramdisks
 This works on linux or with cygwin (with cpio and gzip installed)
 Keep the ramdisk.cpio.gz or initrd.img file inside input folder and run this  
 
@@ -158,7 +158,7 @@ If you face any problem on MacOSX or cygwin (ramdisk not properly getting packed
 
 	./edit-ramdisk/extract-alt
 _ _ _
-#####2. (re)packing ramdisks
+##### 2. (re)packing ramdisks
 This works on linux or with cygwin (with cpio and gzip installed)
 Keep the ramdisk folder inside input folder named as "ramdisk-folder" and run this  
 
@@ -185,8 +185,8 @@ ______________________
 This uses rgb2565 and 5652rgb binaries. If those precompiled binaries are not found, the script will compile them during execution using GNU C Compiler.
 Also ImageMagick program should be installed on your system
 
-#####1. Converting png image to rle format
-######for linux   
+##### 1. Converting png image to rle format
+###### for linux   
 <sup>NOTE: The script will ask you the size (width x height) of image while execution</sup>   
 
 keep your png file named as 'bootsplash.png' in input folder and run this   
@@ -199,7 +199,7 @@ or for more advanced functionality use argument to call the file
 
 The converted file will be found as 'bootsplash.rle' inside output folder
 
-######for windows 
+###### for windows 
 This runs natively on windows (without cygwin)   
 
 place the png file inside edit-image folder and run this from command   
@@ -209,8 +209,8 @@ place the png file inside edit-image folder and run this from command
 
 the output will be filename.png.rle inside the same folder   
 
-#####2. Convert rle bootlogo to png image file
-######for Linux
+##### 2. Convert rle bootlogo to png image file
+###### for Linux
 <sup>NOTE: The script will ask you the size (width x height) of image while execution</sup>   
 
 keep your rle file named as 'bootsplash.rle' in input folder and run this   
@@ -223,7 +223,7 @@ or for more advanced functionality use argument to call the file
 
 The converted file will be found as 'bootsplash.png' inside output folder
 
-######for windows 
+###### for windows 
 This runs natively on windows.   
 
 IMPORTANT: The default size is 480x854. For other sizes please manually edit the rle2png.bat file before using it.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
